### PR TITLE
Implement Authorization Callback Function

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -532,7 +532,7 @@ func TestGetInvalidKeys(t *testing.T) {
 
 func TestNewFileClient(t *testing.T) {
 	if isKnoxDaemonRunning() {
-		t.Skip("Knox daemon is not running, skipping the test.")
+		t.Skip("Knox daemon is running, skipping the test.")
 	}
 
 	_, err := NewFileClient("ThisKeyDoesNotExistSoWeExpectAnError")

--- a/client_test.go
+++ b/client_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path"
 	"reflect"
+	"runtime"
 	"sync/atomic"
 	"testing"
 )
@@ -87,11 +88,20 @@ func buildConcurrentServer(code int, a func(r *http.Request) []byte) *httptest.S
 }
 
 func isKnoxDaemonRunning() bool {
-	cmd := exec.Command("pgrep", "knox")
+	if runtime.GOOS != "linux" {
+		return false
+	}
+
+	cmd := exec.Command("systemctl", "is-active", "--quiet", "knox")
+
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	err := cmd.Run()
-	return err == nil
+	if err == nil {
+		return true
+	}
+
+	return false
 }
 
 func TestGetKey(t *testing.T) {

--- a/knox.go
+++ b/knox.go
@@ -508,6 +508,14 @@ type Principal interface {
 	CanAccess(ACL, AccessType) bool
 	GetID() string
 	Type() string
+	Raw() []RawPrincipal
+}
+
+// RawPrincipal is a serializable version of a principal for passing to
+// access callbacks.
+type RawPrincipal struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
 }
 
 // PrincipalMux provides a Principal Interface over multiple Principals.
@@ -564,6 +572,15 @@ func (p PrincipalMux) Default() Principal {
 	return p.defaultPrincipal
 }
 
+// Raw returns the raw version of all the principals.
+func (p PrincipalMux) Raw() []RawPrincipal {
+	raw := []RawPrincipal{}
+	for _, principal := range p.allPrincipals {
+		raw = append(raw, principal.Raw()...)
+	}
+	return raw
+}
+
 // NewPrincipalMux returns a Principal that represents many principals.
 func NewPrincipalMux(defaultPrincipal Principal, allPrincipals map[string]Principal) Principal {
 	return PrincipalMux{
@@ -598,4 +615,11 @@ type Response struct {
 	Timestamp int64       `json:"ts"`
 	Message   string      `json:"message"`
 	Data      interface{} `json:"data"`
+}
+
+// AccessCallbackInput is the input to the access callback function.
+type AccessCallbackInput struct {
+	Key        Key            `json:"key"`
+	Principals []RawPrincipal `json:"principals"`
+	AccessType AccessType     `json:"access_type"`
 }

--- a/server/api.go
+++ b/server/api.go
@@ -294,6 +294,13 @@ func AddDefaultAccess(a *knox.Access) {
 	defaultAccess = append(defaultAccess, *a)
 }
 
+var accessCallback func(knox.AccessCallbackInput) bool
+
+// SetAccessCallback adds a callback.
+func SetAccessCallback(callback func(knox.AccessCallbackInput) bool) {
+	accessCallback = callback
+}
+
 // Extra validators to apply on principals submitted to Knox.
 var extraPrincipalValidators []knox.PrincipalValidator
 

--- a/server/api.go
+++ b/server/api.go
@@ -294,10 +294,10 @@ func AddDefaultAccess(a *knox.Access) {
 	defaultAccess = append(defaultAccess, *a)
 }
 
-var accessCallback func(knox.AccessCallbackInput) bool
+var accessCallback func(knox.AccessCallbackInput) (bool, error)
 
 // SetAccessCallback adds a callback.
-func SetAccessCallback(callback func(knox.AccessCallbackInput) bool) {
+func SetAccessCallback(callback func(knox.AccessCallbackInput) (bool, error)) {
 	accessCallback = callback
 }
 

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -110,6 +110,10 @@ func TestAddDefaultAccess(t *testing.T) {
 }
 
 func TestSetAccessCallback(t *testing.T) {
+	defer func() {
+		SetAccessCallback(nil) // Resetting the callback
+	}()
+
 	SetAccessCallback(mockAccessCallback)
 
 	input := knox.AccessCallbackInput{}

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -49,8 +49,8 @@ func additionalMockHandler(m KeyManager, principal knox.Principal, parameters ma
 	return "The meaning of life is 42", nil
 }
 
-func mockAccessCallback(input knox.AccessCallbackInput) bool {
-	return true
+func mockAccessCallback(input knox.AccessCallbackInput) (bool, error) {
+	return true, nil
 }
 
 func mockRoute() Route {
@@ -117,7 +117,13 @@ func TestSetAccessCallback(t *testing.T) {
 	if accessCallback == nil {
 		t.Fatal("accessCallback should not be nil")
 	}
-	if !accessCallback(input) {
+
+	canAccess, err := accessCallback(input)
+	if err != nil {
+		t.Fatal("accessCallback should not return an error")
+	}
+
+	if !canAccess {
 		t.Fatal("accessCallback should return true")
 	}
 }

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -49,6 +49,10 @@ func additionalMockHandler(m KeyManager, principal knox.Principal, parameters ma
 	return "The meaning of life is 42", nil
 }
 
+func mockAccessCallback(input knox.AccessCallbackInput) bool {
+	return true
+}
+
 func mockRoute() Route {
 	return Route{
 		Method:     "GET",
@@ -103,6 +107,19 @@ func TestAddDefaultAccess(t *testing.T) {
 	}
 	defaultAccess = []knox.Access{}
 
+}
+
+func TestSetAccessCallback(t *testing.T) {
+	SetAccessCallback(mockAccessCallback)
+
+	input := knox.AccessCallbackInput{}
+
+	if accessCallback == nil {
+		t.Fatal("accessCallback should not be nil")
+	}
+	if !accessCallback(input) {
+		t.Fatal("accessCallback should return true")
+	}
 }
 
 func TestParseFormParameter(t *testing.T) {

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -383,8 +383,8 @@ func (u user) GetID() string {
 func (u user) Raw() []knox.RawPrincipal {
 	return []knox.RawPrincipal{
 		{
-			ID:   u.ID,
-			Type: "user",
+			ID:   u.GetID(),
+			Type: u.Type(),
 		},
 	}
 }
@@ -427,8 +427,8 @@ func (m machine) Type() string {
 func (m machine) Raw() []knox.RawPrincipal {
 	return []knox.RawPrincipal{
 		{
-			ID:   string(m),
-			Type: "machine",
+			ID:   m.GetID(),
+			Type: m.Type(),
 		},
 	}
 }
@@ -471,8 +471,8 @@ func (s service) Type() string {
 func (s service) Raw() []knox.RawPrincipal {
 	return []knox.RawPrincipal{
 		{
-			ID:   "spiffe://" + s.domain + "/" + s.id,
-			Type: "service",
+			ID:   s.GetID(),
+			Type: s.Type(),
 		},
 	}
 }

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -380,6 +380,15 @@ func (u user) GetID() string {
 	return u.ID
 }
 
+func (u user) Raw() []knox.RawPrincipal {
+	return []knox.RawPrincipal{
+		{
+			ID:   u.ID,
+			Type: "user",
+		},
+	}
+}
+
 // Type returns the underlying type of a principal, for logging/debugging purposes.
 func (u user) Type() string {
 	return "user"
@@ -415,6 +424,15 @@ func (m machine) Type() string {
 	return "machine"
 }
 
+func (m machine) Raw() []knox.RawPrincipal {
+	return []knox.RawPrincipal{
+		{
+			ID:   string(m),
+			Type: "machine",
+		},
+	}
+}
+
 // CanAccess determines if a Machine can access an object represented by the ACL
 // with a certain AccessType. It compares Machine hostname and hostname prefix.
 func (m machine) CanAccess(acl knox.ACL, t knox.AccessType) bool {
@@ -448,6 +466,15 @@ func (s service) GetID() string {
 // Type returns the underlying type of a principal, for logging/debugging purposes.
 func (s service) Type() string {
 	return "service"
+}
+
+func (s service) Raw() []knox.RawPrincipal {
+	return []knox.RawPrincipal{
+		{
+			ID:   "spiffe://" + s.domain + "/" + s.id,
+			Type: "service",
+		},
+	}
 }
 
 // CanAccess determines if a Service can access an object represented by the ACL

--- a/server/routes.go
+++ b/server/routes.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/pinterest/knox"
+	"github.com/pinterest/knox/log"
 	"github.com/pinterest/knox/server/auth"
 )
 
@@ -448,6 +449,12 @@ func putVersionsHandler(m KeyManager, principal knox.Principal, parameters map[s
 }
 
 func authorizeRequest(key *knox.Key, principal knox.Principal, access knox.AccessType) bool {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("Recovered from panic in access callback: %v", r)
+		}
+	}()
+
 	if principal.CanAccess(key.ACL, access) {
 		return true
 	}

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -641,6 +641,10 @@ func TestAuthorizeRequest(t *testing.T) {
 		err        error
 	)
 
+	defer func() {
+		SetAccessCallback(nil) // Resetting the callback
+	}()
+
 	SetAccessCallback(mockCallbackTrue)
 	authorized, err = authorizeRequest(key, u, knox.Write)
 	if err != nil {

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -631,6 +631,11 @@ func TestAuthorizeRequest(t *testing.T) {
 		return input.AccessType == knox.Write && input.Key.ACL[0].ID == "test" && input.Key.ACL[0].Type == knox.User
 	}
 
+	// Mock callback that panics
+	mockCallbackPanic := func(input knox.AccessCallbackInput) bool {
+		panic("intentional panic")
+	}
+
 	SetAccessCallback(mockCallbackTrue)
 	if !authorizeRequest(key, u, knox.Write) {
 		t.Fatal("Expected authorizeRequest to return true when accessCallback returns true")
@@ -649,5 +654,10 @@ func TestAuthorizeRequest(t *testing.T) {
 	SetAccessCallback(nil)
 	if authorizeRequest(key, u, knox.Write) {
 		t.Fatal("Expected authorizeRequest to return false when accessCallback is nil")
+	}
+
+	SetAccessCallback(mockCallbackPanic)
+	if authorizeRequest(key, u, knox.Write) {
+		t.Fatal("Expected authorizeRequest to return false when accessCallback panics")
 	}
 }


### PR DESCRIPTION
This will implement a new Callback function for access in Knox. The basic functionality of this function is to allow setting a callback function for Access Control. 
This will be used to allow defining a fallback for custom access control. 

New function SetAccessCallback implemented which takes a callback function that gets passed type AccessCallbackInput, which contains information about the key, principals, and access type.
